### PR TITLE
Route Guards

### DIFF
--- a/TPFinalLaboIV/.gitignore
+++ b/TPFinalLaboIV/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 .angular/
+../node_modules

--- a/TPFinalLaboIV/src/app/app.routes.ts
+++ b/TPFinalLaboIV/src/app/app.routes.ts
@@ -7,23 +7,24 @@ import { PedidosPageComponent } from './pedidos/pages/pedidos-page/pedidos-page.
 import { PresupuestoPageComponent } from './presupuestos/pages/presupuesto-page/presupuesto-page.component';
 import { ListPedidosPageComponent } from './pedidos/pages/list-pedidos-page/list-pedidos-page.component';
 import { UpdatePageComponent } from './clientes/pages/update-page/update-page.component';
+import {NavbarGuard} from "./navbar.guard";
 
 export const routes: Routes = [
 
     //Presupuestos
-    {path: 'presupuestos', component: PresupuestoPageComponent},
+    {path: 'presupuestos', component: PresupuestoPageComponent, canActivate: [NavbarGuard]},
 
     //Clientes
-    {path: 'crearCliente', component: ClienteAddComponent},
-    {path: 'clientes', component: ClienteListComponent},
-    {path: 'clientes/update/:id', component: UpdatePageComponent},
+    {path: 'crearCliente', component: ClienteAddComponent, canActivate: [NavbarGuard]},
+    {path: 'clientes', component: ClienteListComponent, canActivate: [NavbarGuard]},
+    {path: 'clientes/update/:id', component: UpdatePageComponent, canActivate: [NavbarGuard]},
 
 
     //Pedidos
-    {path: 'addPedido', component: PedidosPageComponent},
-    {path: 'pedidos', component: ListPedidosPageComponent},
-    {path: 'addPedidos', component: PedidosPageComponent},
-    {path: "pedidos/update/:id", component: UpdatePedidosPageComponent},
+    {path: 'addPedido', component: PedidosPageComponent, canActivate: [NavbarGuard]},
+    {path: 'pedidos', component: ListPedidosPageComponent, canActivate: [NavbarGuard]},
+    {path: 'addPedidos', component: PedidosPageComponent, canActivate: [NavbarGuard]},
+    {path: "pedidos/update/:id", component: UpdatePedidosPageComponent, canActivate: [NavbarGuard]},
     
     //Por Defecto
     {path: '', component: CuerpoComponent},


### PR DESCRIPTION
Añadida implementación de route guards.
Cree un módulo llamado NavbarGuard que se encarga de determinar si se puede acceder a la ruta pedida. Implementa la funcion canActivate(), que devuelve false si el usuario no usó la barra de navegación.

En app.routes, en todas las rutas se repite el atributo canActivate. Se puede construir un sistema de jerarquía para no tener que repetir lo mismo, pero habría que hacer UrlTrees y cosas raras.